### PR TITLE
Update example to include error function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+This is a fork of the altrunner version of the original library. altrunner converted the library to use char arrays instrad of String types. This has the potential to save memory resources.
+
+This fork here has an updated example which has been corrected to work with a previous library update which added error reporting.
+
+The plan is to add a better example in the future that show how to use the parser.
+
+The original ReadMe is below.
+
 # json-streaming-parser
 Arduino library for parsing potentially huge json streams on devices with scarce memory.
 

--- a/examples/JsonStreamingParser/ExampleParser.cpp
+++ b/examples/JsonStreamingParser/ExampleParser.cpp
@@ -40,3 +40,7 @@ void ExampleListener::startObject() {
    Serial.println("start object. ");
 }
 
+void ExampleListener::error( const char *message ) {
+  Serial.print("message: ");
+  Serial.print(message);
+}

--- a/examples/JsonStreamingParser/ExampleParser.cpp
+++ b/examples/JsonStreamingParser/ExampleParser.cpp
@@ -7,7 +7,7 @@ void ExampleListener::whitespace(char c) {
 }
 
 void ExampleListener::startDocument() {
-  Serial.println("start document");
+  Serial.println("\nstart document");
 }
 
 void ExampleListener::key(const char *key) {
@@ -17,7 +17,7 @@ void ExampleListener::key(const char *key) {
 
 void ExampleListener::value(const char *value) {
   Serial.print("value: ");
-  Serial.print(value);
+  Serial.println(value);
 }
 
 void ExampleListener::endArray() {
@@ -41,6 +41,6 @@ void ExampleListener::startObject() {
 }
 
 void ExampleListener::error( const char *message ) {
-  Serial.print("message: ");
-  Serial.print(message);
+  Serial.print("\nError message: ");
+  Serial.println(message);
 }

--- a/examples/JsonStreamingParser/ExampleParser.h
+++ b/examples/JsonStreamingParser/ExampleParser.h
@@ -22,4 +22,6 @@ class ExampleListener: public JsonListener {
     virtual void startArray();
 
     virtual void startObject();
+
+    virtual void error( const char *message );
 };


### PR DESCRIPTION
The library has been updated in the past and requires an error()
function to be declared in the example class otherwise the example will
not compile.

Compile error was:
"cannot declare variable 'listener' to be of abstract type 'ExampleListener'"